### PR TITLE
NO_OUTPUT option

### DIFF
--- a/teamcity_extra/messages.py
+++ b/teamcity_extra/messages.py
@@ -1,5 +1,7 @@
 from teamcity.messages import TeamcityServiceMessages as _TSM
 
+NO_OUTPUT = object()
+
 
 class TeamcityServiceMessages(_TSM):
     def testMetadata(self, testName, name, value='', type='', flowId=None):
@@ -17,3 +19,13 @@ class TeamcityServiceMessages(_TSM):
     def removeBuildTag(self, tag):
         # https://www.jetbrains.com/help/teamcity/service-messages.html#Adding+and+Removing+Build+Tags
         self._single_value_message('removeBuildTag', tag)
+
+    def message(self, messageName, **properties):
+        if self.output == NO_OUTPUT:
+            return
+        return super().message(messageName, **properties)
+
+    def _single_value_message(self, messageName, value):
+        if self.output == NO_OUTPUT:
+            return
+        return super()._single_value_message(messageName, value)

--- a/tests/other_time_null_output.py
+++ b/tests/other_time_null_output.py
@@ -1,0 +1,80 @@
+"""
+Quick script to test timings on different approaches to null output
+
+NOT A UNIT TEST
+"""
+
+# make sure package is in PATH, as this will depend how the script is executed
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).absolute().parent.parent))
+
+import timeit
+
+from teamcity_extra import messages
+
+TEST_STMT = "tsm.buildStatus(None, '1 2 3 check check')"
+
+
+def tsm_devnull():
+    import os
+
+    devnull = open(os.devnull, 'wb')
+    return messages.TeamcityServiceMessages(output=devnull)
+
+
+def tsm_bytesio():
+    from io import BytesIO
+
+    return messages.TeamcityServiceMessages(output=BytesIO())
+
+
+def tsm_custom():
+    class _devnull:
+        def write(*a, **b):
+            """emptiness"""
+
+        def flush(*a, **b):
+            """emptiness"""
+
+    return messages.TeamcityServiceMessages(output=_devnull())
+
+
+def tsm_mock():
+    from unittest.mock import MagicMock
+
+    return messages.TeamcityServiceMessages(output=MagicMock(encoding='ascii'))
+
+
+def tsm_no_hack():
+    class _X(messages.TeamcityServiceMessages):
+        def message(self, messageName, **properties):
+            return
+
+        def _single_value_message(self, messageName, value):
+            return
+
+    return _X()
+
+
+def timethis(setup):
+    return timeit.timeit(stmt=TEST_STMT, setup=setup, globals=globals(), number=100000)
+
+
+def report():
+    for test in (
+        'tsm = tsm_devnull()',
+        'tsm = tsm_bytesio()',
+        'tsm = tsm_custom()',
+        'tsm = tsm_mock()',
+        'tsm = tsm_no_hack()',
+    ):
+        try:
+            print(test, ':', timethis(test))
+        except Exception as e:
+            print(test, '!!:!!', str(e))
+
+
+if __name__ == '__main__':
+    report()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,4 @@
+import contextlib
 import io
 import time
 from datetime import datetime
@@ -50,4 +51,24 @@ class Test(TestCase):
         self.tsm.removeBuildTag('customTag')
         self.assertOutput(
             "##teamcity[removeBuildTag 'customTag']\n",
+        )
+
+    def test_default_output(self):
+        f = io.BytesIO()
+        with contextlib.redirect_stdout(f):
+            tsm = messages.TeamcityServiceMessages()
+            tsm.removeBuildTag('customTag')
+        self.assertEqual(
+            f.getvalue(),
+            b"##teamcity[removeBuildTag 'customTag']\n",
+        )
+
+    def test_no_output(self):
+        f = io.BytesIO()
+        with contextlib.redirect_stdout(f):
+            tsm = messages.TeamcityServiceMessages(output=messages.NO_OUTPUT)
+            tsm.removeBuildTag('customTag')
+        self.assertEqual(
+            f.getvalue(),
+            b"",
         )


### PR DESCRIPTION
`output=NO_OUTPUT` will not print any service messages.

This allows simpler code in scripts that conditionally enable Teamcity messages:
* only needs to check the condition when instatiating `TeamcityServiceMessages` rather than on every service message call